### PR TITLE
Refactor: Rename TableAgent to NexQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TableAgent
+# NexQuery
 
-TableAgent is a Streamlit-based application that ingests CSV, XLSX, or JSON files to build a SQLite database and leverages a local language model (LLM) to generate SQL queries from natural language questions. The generated queries are executed against the database, and the results—as well as a human-readable explanation of the query—are presented to the user. In addition, the app automatically constructs a combined JSON schema for the table (with details from the SQL metadata, sample data, and an optional data dictionary) that helps guide the LLM to generate accurate, case-insensitive SQL queries. The design is extensible to support multiple tables in the future.
+NexQuery is a Streamlit-based application that ingests CSV, XLSX, or JSON files to build a SQLite database and leverages a local language model (LLM) to generate SQL queries from natural language questions. The generated queries are executed against the database, and the results—as well as a human-readable explanation of the query—are presented to the user. In addition, the app automatically constructs a combined JSON schema for the table (with details from the SQL metadata, sample data, and an optional data dictionary) that helps guide the LLM to generate accurate, case-insensitive SQL queries. The design is extensible to support multiple tables in the future.
 
 ## Features
 
@@ -53,21 +53,21 @@ Additional dependencies might be required by your local LLM server.
 
 ### 1. Clone the Repository
 ```sh
-git clone https://github.com/o6-webwork/tableagent.git
-cd tableagent
+git clone https://github.com/o6-webwork/nexquery.git
+cd nexquery
 ```
 
 ### 2. Run with Docker (Recommended)
-To avoid dependency conflicts, you can run TableAgent inside a Docker container.
+To avoid dependency conflicts, you can run NexQuery inside a Docker container.
 
 #### **Building the Docker Image**
 ```sh
-docker build -t tableagent .
+docker build -t nexquery .
 ```
 
 #### **Running the Container**
 ```sh
-docker run --rm -p 8501:8501 tableagent
+docker run --rm -p 8501:8501 nexquery
 ```
 - `--rm` removes the container automatically after it stops, keeping things clean.
 - `-p 8501:8501` maps the container's port to the host, making the Streamlit app accessible at `http://localhost:8501`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
-  tableagent:
+  nexquery:
     build:
       context: .
     ports:
       - "8501:8501"
-    container_name: tableagent
+    container_name: nexquery
     environment:
       - LLM_BASE_URL=http://127.0.0.1:8000/v1
       - OPENAI_API_KEY=token-abc123

--- a/table_agent.py
+++ b/table_agent.py
@@ -70,7 +70,7 @@ def confirm_mod():
 # 1. GENERALIZED FILE INPUT & DATA LOAD
 ######################################
 st.set_page_config(layout="wide")
-st.title("TableAgent")
+st.title("NexQuery")
 st.markdown(
     """
     Upload a CSV, XLSX, or JSON file. The app will ingest the data, build a database, and allow you to ask SQL-based questions.

--- a/table_rag.py
+++ b/table_rag.py
@@ -63,7 +63,7 @@ st.session_state["db_file"] = db_file
 ######################################
 
 st.set_page_config(layout="wide")
-st.title("TableAgent")
+st.title("NexQuery")
 st.markdown(
     """
     Upload a CSV, XLSX, or JSON file. The app will ingest the data, build a database, and allow you to ask SQL-based questions.


### PR DESCRIPTION
## Summary
- Renamed application from TableAgent to NexQuery across the entire codebase
- Updated all user-facing titles in the Streamlit UI
- Updated documentation and README with new name
- Updated Docker configuration (service name, container name, build tags)
- Updated repository references in installation instructions

## Files Changed
- `README.md` - Updated title, description, and installation instructions
- `table_agent.py` - Updated Streamlit page title
- `table_rag.py` - Updated Streamlit page title  
- `docker-compose.yml` - Updated service and container names

## Test Plan
- [ ] Verify application launches successfully with new title
- [ ] Verify Docker build works with new image name
- [ ] Verify Docker Compose works with new service name
- [ ] Review all documentation for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)